### PR TITLE
has alerts colors important

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9563,3 +9563,12 @@ body.md-skin {
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
   .iti__flag {background-image: url("../img/intlTelInput/flags@2x.png");}
 }
+
+.form-group.has-warning .fileinput .fileinput-preview{color:#8a6d3b !important}
+.form-group.has-warning .fileinput .thumbnail{border-color:#faebcc !important}
+
+.form-group.has-error .fileinput .fileinput-preview{color:#a94442 !important}
+.form-group.has-error .fileinput .thumbnail{border-color:#ebccd1 !important}
+
+.form-group.has-success .fileinput .fileinput-preview{color:#3c763d !important}
+.form-group.has-success .fileinput .thumbnail{border-color:#d6e9c6 !important}


### PR DESCRIPTION
https://github.com/jackocnr/intl-tel-input 
Validadores de campos, Errores dinamico, solo se muestra mexico en el pais, aun falta obtener el country seleccionado en el telefono para q en algun futuro se puedan agregar mas paises y asi poder guardar cada country code y tener una referencia del telefono y del usuario, asi tambien aun falta agregar un nuevo archivo llamado dinamicformerror.js esto para poder utilizar el despliegue de errores mas vistosos en cada uno de los registros o forms futuros o actuales.Se crearon dos nuevas carpetas dentro de css, img las cuales contienen la data de International Telephone Input, se agrego una nueva clase en style.css la cual no afecta a lo antes establecido solo es para el International Telephone Input.